### PR TITLE
Adapt to Script Hash Identification Change

### DIFF
--- a/src/bctklib-3/ContractParameterParser.cs
+++ b/src/bctklib-3/ContractParameterParser.cs
@@ -212,7 +212,14 @@ namespace Neo.BlockchainToolkit
                 return true;
             }
 
-            var nativeContract = NativeContract.Contracts.SingleOrDefault(c => c.Name.Equals(text, StringComparison.OrdinalIgnoreCase));
+            var nativeContract = NativeContract.Contracts.SingleOrDefault(c => string.Equals(text, c.Name));
+            if (nativeContract != null)
+            {
+                value = nativeContract.Hash;
+                return true;
+            }
+
+            nativeContract = NativeContract.Contracts.SingleOrDefault(c => string.Equals(text, c.Name, StringComparison.OrdinalIgnoreCase));
             if (nativeContract != null)
             {
                 value = nativeContract.Hash;

--- a/src/bctklib-3/bctklib-3.csproj
+++ b/src/bctklib-3/bctklib-3.csproj
@@ -39,11 +39,15 @@
   <ItemGroup>
     <PackageReference Include="MessagePack" Version="2.2.60" />
     <PackageReference Condition="'$(Configuration)'!='Debug'" Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Neo" Version="3.0.0-mono-master-00328" />
+    <PackageReference Include="Neo" Version="3.0.0-mono-master-00349" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OneOf" Version="2.1.155" />
     <PackageReference Include="rocksdb" Version="6.12.7.13237" />
     <PackageReference Include="System.IO.Abstractions" Version="12.2.19" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- <ProjectReference Include="..\..\..\..\official\3neo-monorepo\core\src\neo\neo.csproj" /> -->
   </ItemGroup>
 
 </Project>

--- a/src/bctklib-3/trace-models/Formatters/UInt160Formatter.cs
+++ b/src/bctklib-3/trace-models/Formatters/UInt160Formatter.cs
@@ -12,13 +12,11 @@ namespace MessagePack.Formatters.Neo.BlockchainToolkit.TraceDebug
         public UInt160 Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
         {
             var seq = reader.ReadRaw(UInt160.Length);
-            // TODO: avoid array creation by adding ReadOnlySequence<byte> ctor to uint160
-            return new UInt160(seq.ToArray());
+            return new UInt160(seq.IsSingleSegment ? seq.FirstSpan : seq.ToArray());
         }
 
         public void Serialize(ref MessagePackWriter writer, UInt160 value, MessagePackSerializerOptions options)
         {
-            // TODO: avoid array creation by adding AsSpan method to uint160
             writer.WriteRaw(value.ToArray().AsSpan(0, UInt160.Length));
         }
     }

--- a/src/bctklib-3/trace-models/LogRecord.cs
+++ b/src/bctklib-3/trace-models/LogRecord.cs
@@ -11,21 +11,25 @@ namespace Neo.BlockchainToolkit.TraceDebug
         [Key(0)]
         public readonly UInt160 ScriptHash;
         [Key(1)]
+        public readonly string ScriptName;
+        [Key(2)]
         public readonly string Message;
 
-        public LogRecord(UInt160 scriptHash, string message)
+        public LogRecord(UInt160 scriptHash, string scriptName, string message)
         {
             ScriptHash = scriptHash;
+            ScriptName = scriptName;
             Message = message;
         }
 
-        public static void Write(IBufferWriter<byte> writer, MessagePackSerializerOptions options, UInt160 scriptHash, string message)
+        public static void Write(IBufferWriter<byte> writer, MessagePackSerializerOptions options, UInt160 scriptHash, string scriptName, string message)
         {
             var mpWriter = new MessagePackWriter(writer);
             mpWriter.WriteArrayHeader(2);
             mpWriter.WriteInt32(RecordKey);
-            mpWriter.WriteArrayHeader(2);
+            mpWriter.WriteArrayHeader(3);
             options.Resolver.GetFormatterWithVerify<Neo.UInt160>().Serialize(ref mpWriter, scriptHash, options);
+            options.Resolver.GetFormatterWithVerify<string>().Serialize(ref mpWriter, scriptName, options);
             options.Resolver.GetFormatterWithVerify<string>().Serialize(ref mpWriter, message, options);
             mpWriter.Flush();
         }

--- a/src/bctklib-3/trace-models/NotifyRecord.cs
+++ b/src/bctklib-3/trace-models/NotifyRecord.cs
@@ -14,24 +14,28 @@ namespace Neo.BlockchainToolkit.TraceDebug
         [Key(0)]
         public readonly UInt160 ScriptHash;
         [Key(1)]
-        public readonly string EventName;
+        public readonly string ScriptName;
         [Key(2)]
+        public readonly string EventName;
+        [Key(3)]
         public readonly IReadOnlyList<StackItem> State;
 
-        public NotifyRecord(UInt160 scriptHash, string eventName, IReadOnlyList<StackItem> state)
+        public NotifyRecord(UInt160 scriptHash, string scriptName, string eventName, IReadOnlyList<StackItem> state)
         {
             ScriptHash = scriptHash;
+            ScriptName = scriptName;
             EventName = eventName;
             State = state;
         }
 
-        public static void Write(IBufferWriter<byte> writer, MessagePackSerializerOptions options, UInt160 scriptHash, string eventName, IReadOnlyCollection<StackItem> state)
+        public static void Write(IBufferWriter<byte> writer, MessagePackSerializerOptions options, UInt160 scriptHash, string scriptName, string eventName, IReadOnlyCollection<StackItem> state)
         {
             var mpWriter = new MessagePackWriter(writer);
             mpWriter.WriteArrayHeader(2);
             mpWriter.WriteInt32(RecordKey);
-            mpWriter.WriteArrayHeader(3);
+            mpWriter.WriteArrayHeader(4);
             options.Resolver.GetFormatterWithVerify<UInt160>().Serialize(ref mpWriter, scriptHash, options);
+            options.Resolver.GetFormatterWithVerify<string>().Serialize(ref mpWriter, scriptName, options);
             options.Resolver.GetFormatterWithVerify<string>().Serialize(ref mpWriter, eventName, options);
             mpWriter.WriteArrayHeader(state.Count);
             foreach (var item in state)

--- a/src/bctklib-3/trace-models/TraceRecord.StackFrame.cs
+++ b/src/bctklib-3/trace-models/TraceRecord.StackFrame.cs
@@ -9,25 +9,36 @@ namespace Neo.BlockchainToolkit.TraceDebug
 {
     public partial class TraceRecord
     {
+        // Note, Neo 3 calculates the script hash used to identify a contract from the script binary at initial deployment + the address of the contract deployer
+        // This enables a stable contract identifier, even as the contract is later updated.
+        // However, debugging requires the SHA 256 hash of the script binary to tie a specific contract version to its associated debug info.
+
+        // In TraceRecord:
+        //   * ScriptIdentifier property is the UInt160 value created on script deployment that identifies a contract (even after updates)
+        //   * ScriptHash is the SHA 256 hash of the script binary, needed to map scripts to debug info
+
         [MessagePackObject]
         public class StackFrame
         {
             [Key(0)]
-            public readonly UInt160 ScriptHash;
+            public readonly UInt160 ScriptIdentifier;
             [Key(1)]
-            public readonly int InstructionPointer;
+            public readonly UInt160 ScriptHash;
             [Key(2)]
-            public readonly bool HasCatch;
+            public readonly int InstructionPointer;
             [Key(3)]
-            public readonly IReadOnlyList<StackItem> EvaluationStack;
+            public readonly bool HasCatch;
             [Key(4)]
-            public readonly IReadOnlyList<StackItem> LocalVariables;
+            public readonly IReadOnlyList<StackItem> EvaluationStack;
             [Key(5)]
-            public readonly IReadOnlyList<StackItem> StaticFields;
+            public readonly IReadOnlyList<StackItem> LocalVariables;
             [Key(6)]
+            public readonly IReadOnlyList<StackItem> StaticFields;
+            [Key(7)]
             public readonly IReadOnlyList<StackItem> Arguments;
 
             public StackFrame(
+                UInt160 scriptIdentifier,
                 UInt160 scriptHash,
                 int instructionPointer,
                 bool hasCatch,
@@ -36,6 +47,7 @@ namespace Neo.BlockchainToolkit.TraceDebug
                 IReadOnlyList<StackItem> staticFields,
                 IReadOnlyList<StackItem> arguments)
             {
+                ScriptIdentifier = scriptIdentifier;
                 ScriptHash = scriptHash;
                 InstructionPointer = instructionPointer;
                 HasCatch = hasCatch;
@@ -45,12 +57,20 @@ namespace Neo.BlockchainToolkit.TraceDebug
                 Arguments = arguments;
             }
 
-            internal static void Write(ref MessagePackWriter writer, MessagePackSerializerOptions options, ExecutionContext context)
+            internal static void Write(ref MessagePackWriter writer, MessagePackSerializerOptions options, IDictionary<UInt160, UInt160> scriptIdMap, ExecutionContext context)
             {
+                var scriptId = context.GetScriptHash();
+                if (!scriptIdMap.TryGetValue(scriptId, out var scriptHash))
+                {
+                    scriptHash = Neo.SmartContract.Helper.ToScriptHash(context.Script);
+                    scriptIdMap[scriptId] = scriptHash;
+                }
+
                 var stackItemCollectionResolver = options.Resolver.GetFormatterWithVerify<IReadOnlyCollection<StackItem>>();
 
-                writer.WriteArrayHeader(7);
-                options.Resolver.GetFormatterWithVerify<UInt160>().Serialize(ref writer, context.GetScriptHash(), options);
+                writer.WriteArrayHeader(8);
+                options.Resolver.GetFormatterWithVerify<UInt160>().Serialize(ref writer, scriptId, options);
+                options.Resolver.GetFormatterWithVerify<UInt160>().Serialize(ref writer, scriptHash, options);
                 writer.Write(context.InstructionPointer);
                 writer.Write(context.TryStack?.Any(c => c.HasCatch) == true);
                 stackItemCollectionResolver.Serialize(ref writer, context.EvaluationStack, options);

--- a/src/bctklib-3/trace-models/TraceRecord.cs
+++ b/src/bctklib-3/trace-models/TraceRecord.cs
@@ -23,6 +23,7 @@ namespace Neo.BlockchainToolkit.TraceDebug
 
         public static void Write(IBufferWriter<byte> writer,
                                  MessagePackSerializerOptions options,
+                                 IDictionary<UInt160, UInt160> scriptIdMap,
                                  VMState vmState,
                                  IReadOnlyCollection<ExecutionContext> contexts)
         {
@@ -35,7 +36,7 @@ namespace Neo.BlockchainToolkit.TraceDebug
             mpWriter.WriteArrayHeader(contexts.Count);
             foreach (var context in contexts)
             {
-                StackFrame.Write(ref mpWriter, options, context);
+                StackFrame.Write(ref mpWriter, options, scriptIdMap, context);
             }
             mpWriter.Flush();
         }

--- a/test/test.bctklib-3/ContractParameterParserTest.cs
+++ b/test/test.bctklib-3/ContractParameterParserTest.cs
@@ -18,10 +18,8 @@ namespace test.bctklib3
         public void TestParseStringParameter_string()
         {
             const string expected = "string-value";
-            var fileSystem = new MockFileSystem();
-            var accounts = new Dictionary<string, UInt160>();
-            var parser = new ContractParameterParser(fileSystem, accounts.TryGetValue);
-            var param = parser.ParseStringParameter(expected, string.Empty);
+            var parser = new ContractParameterParser(null, null);
+            var param = parser.ParseStringParameter(expected);
             param.Type.ShouldBe(ContractParameterType.String);
             param.Value.ShouldBe(expected);
         }
@@ -31,13 +29,12 @@ namespace test.bctklib3
         {
             const string account = "test-account";
             var expectedValue = UInt160.Parse("30f41a14ca6019038b055b585d002b287b5fdd47");
-            var fileSystem = new MockFileSystem();
             var accounts = new Dictionary<string, UInt160>
             {
                 { account, expectedValue }
             };
-            var parser = new ContractParameterParser(fileSystem, accounts.TryGetValue);
-            var param = parser.ParseStringParameter($"@{account}", string.Empty);
+            var parser = new ContractParameterParser(tryGetAccount: accounts.TryGetValue);
+            var param = parser.ParseStringParameter($"@{account}");
             param.Type.ShouldBe(ContractParameterType.Hash160);
             param.Value.ShouldBe(expectedValue);
         }
@@ -46,10 +43,8 @@ namespace test.bctklib3
         public void TestParseStringParameter_at_account_missing()
         {
             const string account = "test-account";
-            var fileSystem = new MockFileSystem();
-            var accounts = new Dictionary<string, UInt160>();
-            var parser = new ContractParameterParser(fileSystem, accounts.TryGetValue);
-            var param = parser.ParseStringParameter($"@{account}", string.Empty);
+            var parser = new ContractParameterParser(null, null);
+            var param = parser.ParseStringParameter($"@{account}");
             param.Type.ShouldBe(ContractParameterType.String);
             param.Value.ShouldBe($"@{account}");
         }
@@ -59,10 +54,8 @@ namespace test.bctklib3
         {
             var expectedValue = UInt160.Parse("30f41a14ca6019038b055b585d002b287b5fdd47");
             var address = Neo.Wallets.Helper.ToAddress(expectedValue);
-            var fileSystem = new MockFileSystem();
-            var accounts = new Dictionary<string, UInt160>();
-            var parser = new ContractParameterParser(fileSystem, accounts.TryGetValue);
-            var param = parser.ParseStringParameter($"@{address}", string.Empty);
+            var parser = new ContractParameterParser(null, null);
+            var param = parser.ParseStringParameter($"@{address}");
             param.Type.ShouldBe(ContractParameterType.Hash160);
             param.Value.ShouldBe(expectedValue);
         }
@@ -75,10 +68,8 @@ namespace test.bctklib3
             var address = Neo.Wallets.Helper.ToAddress(uint160);
             var expected = "@" + address.Substring(0, address.Length - 1);
 
-            var fileSystem = new MockFileSystem();
-            var accounts = new Dictionary<string, UInt160>();
-            var parser = new ContractParameterParser(fileSystem, accounts.TryGetValue);
-            var param = parser.ParseStringParameter(expected, string.Empty);
+            var parser = new ContractParameterParser(null, null);
+            var param = parser.ParseStringParameter(expected);
             param.Type.ShouldBe(ContractParameterType.String);
             param.Value.ShouldBe(expected);
         }
@@ -87,10 +78,8 @@ namespace test.bctklib3
         public void TestParseStringParameter_hash_uint160()
         {
             const string hashString = "30f41a14ca6019038b055b585d002b287b5fdd47";
-            var fileSystem = new MockFileSystem();
-            var accounts = new Dictionary<string, UInt160>();
-            var parser = new ContractParameterParser(fileSystem, accounts.TryGetValue);
-            var param = parser.ParseStringParameter($"#{hashString}", string.Empty);
+            var parser = new ContractParameterParser(null, null);
+            var param = parser.ParseStringParameter($"#{hashString}");
             param.Type.ShouldBe(ContractParameterType.Hash160);
             param.Value.ShouldBe(UInt160.Parse(hashString));
         }
@@ -99,10 +88,8 @@ namespace test.bctklib3
         public void TestParseStringParameter_hash_uint160_fail()
         {
             const string hashString = "#30f41a14ca6019038b055b585d002b287b5fdd4";
-            var fileSystem = new MockFileSystem();
-            var accounts = new Dictionary<string, UInt160>();
-            var parser = new ContractParameterParser(fileSystem, accounts.TryGetValue);
-            var param = parser.ParseStringParameter(hashString, string.Empty);
+            var parser = new ContractParameterParser(null, null);
+            var param = parser.ParseStringParameter(hashString);
             param.Type.ShouldBe(ContractParameterType.String);
             param.Value.ShouldBe(hashString);
         }
@@ -111,10 +98,8 @@ namespace test.bctklib3
         public void TestParseStringParameter_hash_uint256()
         {
             const string hashString = "0a372ac8f778eeebb1ccdbb250fe596b83d1d1b9f366d71dfd4c53956bed5cce";
-            var fileSystem = new MockFileSystem();
-            var accounts = new Dictionary<string, UInt160>();
-            var parser = new ContractParameterParser(fileSystem, accounts.TryGetValue);
-            var param = parser.ParseStringParameter($"#{hashString}", string.Empty);
+            var parser = new ContractParameterParser(null, null);
+            var param = parser.ParseStringParameter($"#{hashString}");
             param.Type.ShouldBe(ContractParameterType.Hash256);
             param.Value.ShouldBe(UInt256.Parse(hashString));
         }
@@ -123,10 +108,8 @@ namespace test.bctklib3
         public void TestParseStringParameter_hash_uint256_fail()
         {
             const string hashString = "#a372ac8f778eeebb1ccdbb250fe596b83d1d1b9f366d71dfd4c53956bed5cce";
-            var fileSystem = new MockFileSystem();
-            var accounts = new Dictionary<string, UInt160>();
-            var parser = new ContractParameterParser(fileSystem, accounts.TryGetValue);
-            var param = parser.ParseStringParameter(hashString, string.Empty);
+            var parser = new ContractParameterParser(null, null);
+            var param = parser.ParseStringParameter(hashString);
             param.Type.ShouldBe(ContractParameterType.String);
             param.Value.ShouldBe(hashString);
         }
@@ -137,86 +120,28 @@ namespace test.bctklib3
                 ? @"x:\fakepath" : "/fakepath";
         }
 
-        // [Fact]
-        // public void TestParseStringParameter_hash_script_absolute()
-        // {
-        //     var nef = new NefFile
-        //     {
-        //         Compiler = "".PadLeft(32, ' '),
-        //         Version = new Version(1, 2, 3, 4),
-        //         Script = new byte[] { 0x01, 0x02, 0x03 }
-        //     };
-        //     nef.ScriptHash = nef.Script.ToScriptHash();
-        //     nef.CheckSum = NefFile.ComputeChecksum(nef);
+        [Fact]
+        public void TestParseStringParameter_hash_script()
+        {
+            const string contractName = "test-contract";
+            var expectedValue = UInt160.Parse("30f41a14ca6019038b055b585d002b287b5fdd47");
 
-        //     var fileSystem = new MockFileSystem();
-        //     var nefPath = fileSystem.Path.Combine(FakeRootPath(), "contract.nef");
-        //     fileSystem.AddFile(nefPath, new MockFileData(nef.ToArray()));
+            var contracts = new Dictionary<string, UInt160>()
+            {
+                { contractName, expectedValue }
+            };
 
-        //     var accounts = new Dictionary<string, UInt160>();
-        //     var parser = new ContractParameterParser(fileSystem, accounts.TryGetValue);
-        //     var param = parser.ParseStringParameter($"#{nefPath}", string.Empty);
-        //     param.Type.ShouldBe(ContractParameterType.Hash160);
-        //     param.Value.ShouldBe(nef.ScriptHash);
-        // }
-
-        // [Fact]
-        // public void TestParseStringParameter_hash_script_relative()
-        // {
-        //     var nef = new NefFile
-        //     {
-        //         Compiler = "".PadLeft(32, ' '),
-        //         Version = new Version(1, 2, 3, 4),
-        //         Script = new byte[] { 0x01, 0x02, 0x03 }
-        //     };
-        //     nef.ScriptHash = nef.Script.ToScriptHash();
-        //     nef.CheckSum = NefFile.ComputeChecksum(nef);
-
-        //     var fileSystem = new MockFileSystem();
-        //     var rootPath = FakeRootPath();
-        //     var nefPath = fileSystem.Path.Combine(rootPath, "contract.nef");
-        //     fileSystem.AddFile(nefPath, new MockFileData(nef.ToArray()));
-
-        //     var relativePath = fileSystem.Path.GetRelativePath(rootPath, nefPath);
-
-        //     var accounts = new Dictionary<string, UInt160>();
-        //     var parser = new ContractParameterParser(fileSystem, accounts.TryGetValue);
-        //     var param = parser.ParseStringParameter($"#{relativePath}", rootPath);
-        //     param.Type.ShouldBe(ContractParameterType.Hash160);
-        //     param.Value.ShouldBe(nef.ScriptHash);
-        // }
-
-        // [Fact]
-        // public void TestParseStringParameter_hash_script_relative_invalid()
-        // {
-        //     const string nefPath = @"x:\fakepath\contract.nef";
-        //     var nef = new NefFile
-        //     {
-        //         Compiler = "".PadLeft(32, ' '),
-        //         Version = new Version(1, 2, 3, 4),
-        //         Script = new byte[] { 0x01, 0x02, 0x03 }
-        //     };
-        //     nef.ScriptHash = nef.Script.ToScriptHash();
-        //     nef.CheckSum = NefFile.ComputeChecksum(nef);
-
-        //     var fileSystem = new MockFileSystem();
-        //     fileSystem.AddFile(nefPath, new MockFileData(nef.ToArray()));
-
-        //     var accounts = new Dictionary<string, UInt160>();
-        //     var parser = new ContractParameterParser(fileSystem, accounts.TryGetValue);
-
-        //     var param = parser.ParseStringParameter("#contract.nef", string.Empty);
-        //     param.Type.ShouldBe(ContractParameterType.String);
-        //     param.Value.ShouldBe("#contract.nef");
-        // }
+            var parser = new ContractParameterParser(tryGetContract: contracts.TryGetValue);
+            var param = parser.ParseStringParameter($"#{contractName}");
+            param.Type.ShouldBe(ContractParameterType.Hash160);
+            param.Value.ShouldBe(expectedValue);
+        }
 
         [Fact]
         public void TestParseStringParameter_hash_script_native()
         {
-            var fileSystem = new MockFileSystem();
-            var accounts = new Dictionary<string, UInt160>();
-            var parser = new ContractParameterParser(fileSystem, accounts.TryGetValue);
-            var param = parser.ParseStringParameter("#oracle", string.Empty);
+            var parser = new ContractParameterParser(null, null);
+            var param = parser.ParseStringParameter("#oracle");
             param.Type.ShouldBe(ContractParameterType.Hash160);
             param.Value.ShouldBe(Neo.SmartContract.Native.NativeContract.Oracle.Hash);
         }
@@ -234,10 +159,8 @@ namespace test.bctklib3
                 0x19, 0x1a, 0x1b, 0x1c,
                 0x1d, 0x1e, 0x1f, 0x20 };
 
-            var fileSystem = new MockFileSystem();
-            var accounts = new Dictionary<string, UInt160>();
-            var parser = new ContractParameterParser(fileSystem, accounts.TryGetValue);
-            var param = parser.ParseStringParameter($"0x{expectedValue.ToHexString()}", string.Empty);
+            var parser = new ContractParameterParser(null, null);
+            var param = parser.ParseStringParameter($"0x{expectedValue.ToHexString()}");
             param.Type.ShouldBe(ContractParameterType.ByteArray);
             param.Value.ShouldBe(expectedValue);
         }

--- a/test/test.bctklib-3/ContractParameterParserTest.cs
+++ b/test/test.bctklib-3/ContractParameterParserTest.cs
@@ -137,78 +137,78 @@ namespace test.bctklib3
                 ? @"x:\fakepath" : "/fakepath";
         }
 
-        [Fact]
-        public void TestParseStringParameter_hash_script_absolute()
-        {
-            var nef = new NefFile
-            {
-                Compiler = "".PadLeft(32, ' '),
-                Version = new Version(1, 2, 3, 4),
-                Script = new byte[] { 0x01, 0x02, 0x03 }
-            };
-            nef.ScriptHash = nef.Script.ToScriptHash();
-            nef.CheckSum = NefFile.ComputeChecksum(nef);
+        // [Fact]
+        // public void TestParseStringParameter_hash_script_absolute()
+        // {
+        //     var nef = new NefFile
+        //     {
+        //         Compiler = "".PadLeft(32, ' '),
+        //         Version = new Version(1, 2, 3, 4),
+        //         Script = new byte[] { 0x01, 0x02, 0x03 }
+        //     };
+        //     nef.ScriptHash = nef.Script.ToScriptHash();
+        //     nef.CheckSum = NefFile.ComputeChecksum(nef);
 
-            var fileSystem = new MockFileSystem();
-            var nefPath = fileSystem.Path.Combine(FakeRootPath(), "contract.nef");
-            fileSystem.AddFile(nefPath, new MockFileData(nef.ToArray()));
+        //     var fileSystem = new MockFileSystem();
+        //     var nefPath = fileSystem.Path.Combine(FakeRootPath(), "contract.nef");
+        //     fileSystem.AddFile(nefPath, new MockFileData(nef.ToArray()));
 
-            var accounts = new Dictionary<string, UInt160>();
-            var parser = new ContractParameterParser(fileSystem, accounts.TryGetValue);
-            var param = parser.ParseStringParameter($"#{nefPath}", string.Empty);
-            param.Type.ShouldBe(ContractParameterType.Hash160);
-            param.Value.ShouldBe(nef.ScriptHash);
-        }
+        //     var accounts = new Dictionary<string, UInt160>();
+        //     var parser = new ContractParameterParser(fileSystem, accounts.TryGetValue);
+        //     var param = parser.ParseStringParameter($"#{nefPath}", string.Empty);
+        //     param.Type.ShouldBe(ContractParameterType.Hash160);
+        //     param.Value.ShouldBe(nef.ScriptHash);
+        // }
 
-        [Fact]
-        public void TestParseStringParameter_hash_script_relative()
-        {
-            var nef = new NefFile
-            {
-                Compiler = "".PadLeft(32, ' '),
-                Version = new Version(1, 2, 3, 4),
-                Script = new byte[] { 0x01, 0x02, 0x03 }
-            };
-            nef.ScriptHash = nef.Script.ToScriptHash();
-            nef.CheckSum = NefFile.ComputeChecksum(nef);
+        // [Fact]
+        // public void TestParseStringParameter_hash_script_relative()
+        // {
+        //     var nef = new NefFile
+        //     {
+        //         Compiler = "".PadLeft(32, ' '),
+        //         Version = new Version(1, 2, 3, 4),
+        //         Script = new byte[] { 0x01, 0x02, 0x03 }
+        //     };
+        //     nef.ScriptHash = nef.Script.ToScriptHash();
+        //     nef.CheckSum = NefFile.ComputeChecksum(nef);
 
-            var fileSystem = new MockFileSystem();
-            var rootPath = FakeRootPath();
-            var nefPath = fileSystem.Path.Combine(rootPath, "contract.nef");
-            fileSystem.AddFile(nefPath, new MockFileData(nef.ToArray()));
+        //     var fileSystem = new MockFileSystem();
+        //     var rootPath = FakeRootPath();
+        //     var nefPath = fileSystem.Path.Combine(rootPath, "contract.nef");
+        //     fileSystem.AddFile(nefPath, new MockFileData(nef.ToArray()));
 
-            var relativePath = fileSystem.Path.GetRelativePath(rootPath, nefPath);
+        //     var relativePath = fileSystem.Path.GetRelativePath(rootPath, nefPath);
 
-            var accounts = new Dictionary<string, UInt160>();
-            var parser = new ContractParameterParser(fileSystem, accounts.TryGetValue);
-            var param = parser.ParseStringParameter($"#{relativePath}", rootPath);
-            param.Type.ShouldBe(ContractParameterType.Hash160);
-            param.Value.ShouldBe(nef.ScriptHash);
-        }
+        //     var accounts = new Dictionary<string, UInt160>();
+        //     var parser = new ContractParameterParser(fileSystem, accounts.TryGetValue);
+        //     var param = parser.ParseStringParameter($"#{relativePath}", rootPath);
+        //     param.Type.ShouldBe(ContractParameterType.Hash160);
+        //     param.Value.ShouldBe(nef.ScriptHash);
+        // }
 
-        [Fact]
-        public void TestParseStringParameter_hash_script_relative_invalid()
-        {
-            const string nefPath = @"x:\fakepath\contract.nef";
-            var nef = new NefFile
-            {
-                Compiler = "".PadLeft(32, ' '),
-                Version = new Version(1, 2, 3, 4),
-                Script = new byte[] { 0x01, 0x02, 0x03 }
-            };
-            nef.ScriptHash = nef.Script.ToScriptHash();
-            nef.CheckSum = NefFile.ComputeChecksum(nef);
+        // [Fact]
+        // public void TestParseStringParameter_hash_script_relative_invalid()
+        // {
+        //     const string nefPath = @"x:\fakepath\contract.nef";
+        //     var nef = new NefFile
+        //     {
+        //         Compiler = "".PadLeft(32, ' '),
+        //         Version = new Version(1, 2, 3, 4),
+        //         Script = new byte[] { 0x01, 0x02, 0x03 }
+        //     };
+        //     nef.ScriptHash = nef.Script.ToScriptHash();
+        //     nef.CheckSum = NefFile.ComputeChecksum(nef);
 
-            var fileSystem = new MockFileSystem();
-            fileSystem.AddFile(nefPath, new MockFileData(nef.ToArray()));
+        //     var fileSystem = new MockFileSystem();
+        //     fileSystem.AddFile(nefPath, new MockFileData(nef.ToArray()));
 
-            var accounts = new Dictionary<string, UInt160>();
-            var parser = new ContractParameterParser(fileSystem, accounts.TryGetValue);
+        //     var accounts = new Dictionary<string, UInt160>();
+        //     var parser = new ContractParameterParser(fileSystem, accounts.TryGetValue);
 
-            var param = parser.ParseStringParameter("#contract.nef", string.Empty);
-            param.Type.ShouldBe(ContractParameterType.String);
-            param.Value.ShouldBe("#contract.nef");
-        }
+        //     var param = parser.ParseStringParameter("#contract.nef", string.Empty);
+        //     param.Type.ShouldBe(ContractParameterType.String);
+        //     param.Value.ShouldBe("#contract.nef");
+        // }
 
         [Fact]
         public void TestParseStringParameter_hash_script_native()


### PR DESCRIPTION
This PR adapts BCTK Lib to changes introduced by https://github.com/neo-project/neo/pull/2044

* `ContractParameterParser` no longer supports loading contract hashes from NEF files
* `ContractParameterParser` accepts two delegates for mapping strings to UInt160s: one for addresses (using `@` string prefix) and one for contracts (using `#` prefix)
* Add script identifier to trace debug `TraceRecord.StackFrame`
  * `StackFrame.ScriptIdentifier` is the update-independent identifier generated on contract deploy.
  *  `StackFrame.ScriptHash` is the SHA 256 hash of the script binary (used for mapping scripts to script debug info)
* Add script name to trace debug `LogRecord` and `NotifyRecord`